### PR TITLE
remove device id when user logout

### DIFF
--- a/app/src/main/java/com/example/iqbooster/MainActivity.java
+++ b/app/src/main/java/com/example/iqbooster/MainActivity.java
@@ -549,6 +549,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
             myCollect.setActivityInterface(this);
             setFragment(myCollect);
         } else if (id == mLogoutItem.getItemId()) {
+            FirebaseUtil.removeDeviceId(getApplicationContext(), mAuth.getUid(), TAG);
             mAuth.signOut();
             recreate();
         }

--- a/app/src/main/java/com/example/iqbooster/UserProfilePage.java
+++ b/app/src/main/java/com/example/iqbooster/UserProfilePage.java
@@ -349,6 +349,7 @@ public class UserProfilePage extends AppCompatActivity implements ActivityInterf
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         switch (item.getItemId()) {
             case R.id.threedots_logout:
+                FirebaseUtil.removeDeviceId(getApplicationContext(), mAuth.getUid(), TAG);
                 mAuth.signOut();
                 recreate();
             default:

--- a/app/src/main/java/com/example/iqbooster/notification/FirebaseUtil.java
+++ b/app/src/main/java/com/example/iqbooster/notification/FirebaseUtil.java
@@ -45,6 +45,11 @@ public class FirebaseUtil {
                 });
     }
 
+    public static void removeDeviceId(Context context, String UID, String TAG) {
+        DatabaseReference mUsers = FirebaseDatabase.getInstance().getReference().child(context.getResources().getString(R.string.db_users));
+        mUsers.child(UID).child(context.getString(R.string.db_device_id)).removeValue();
+    }
+
     private static void sendSingleNotification(String device_id, String title, String body, String TAG) {
         Log.d(TAG, device_id);
 
@@ -67,8 +72,6 @@ public class FirebaseUtil {
 
     public static void sendSingleNotification(Context context, String destUID, String title, String body, String TAG) {
         Log.d(TAG, "sending notification");
-        Log.d(TAG, context.getResources().getString(R.string.db_users));
-        Log.d(TAG, context.getResources().getString(R.string.db_device_id));
 
         DatabaseReference mUsers = FirebaseDatabase.getInstance().getReference().child(context.getResources().getString(R.string.db_users));
         mUsers.child(destUID).child(context.getString(R.string.db_device_id)).addListenerForSingleValueEvent(new ValueEventListener() {


### PR DESCRIPTION
Added removeDeviceId to firebaseUtil.
Remove device id when user logout from drawer in the Main Activity or from user profile page.